### PR TITLE
Add communities API endpoints

### DIFF
--- a/src/data/communities.ts
+++ b/src/data/communities.ts
@@ -411,3 +411,21 @@ export const getCommunityById = (id: string): Community | undefined => {
 export const getCommunitiesByIds = (ids: string[]): Community[] => {
   return communities.filter((community) => ids.includes(community.id));
 };
+
+export const getCommunityDomain = (community: Community): string | null => {
+  try {
+    const url = new URL(community.link);
+    return url.hostname.replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+};
+
+export const getCommunityByDomain = (
+  domain: string
+): Community | undefined => {
+  return communities.find((community) => {
+    const communityDomain = getCommunityDomain(community);
+    return communityDomain === domain;
+  });
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,22 @@
 {
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    }
+  ],
   "rewrites": [
+    {
+      "source": "/api/communities",
+      "destination": "/api/communities.json"
+    },
+    {
+      "source": "/api/community/:domain",
+      "destination": "/api/community/:domain.json"
+    },
     {
       "source": "/(.*)",
       "destination": "/index.html"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import remarkFrontmatter from "remark-frontmatter";
 import remarkMdxFrontmatter from "remark-mdx-frontmatter";
 import path from "path";
 import { cards } from "./src/data/cards";
+import { communities, getCommunityDomain } from "./src/data/communities";
 
 export default defineConfig({
   base: "/",
@@ -29,6 +30,76 @@ export default defineConfig({
           fileName: "api/cards.json",
           source: JSON.stringify(cardsWithUrls, null, 2),
         });
+      },
+    },
+    {
+      name: "communities-endpoint",
+      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          if (req.url === "/api/communities") {
+            res.setHeader("Content-Type", "application/json");
+            res.setHeader("Access-Control-Allow-Origin", "*");
+            res.end(JSON.stringify(communities.map((c) => ({
+              ...c,
+              domain: getCommunityDomain(c),
+            }))));
+            return;
+          }
+
+          const match = req.url?.match(/^\/api\/community\/(.+?)$/);
+          if (match) {
+            const domain = decodeURIComponent(match[1]);
+            const community = communities.find(
+              (c) => getCommunityDomain(c) === domain
+            );
+            if (community) {
+              res.setHeader("Content-Type", "application/json");
+              res.setHeader("Access-Control-Allow-Origin", "*");
+              res.end(JSON.stringify({
+                ...community,
+                domain: getCommunityDomain(community),
+              }));
+              return;
+            }
+            res.statusCode = 404;
+            res.setHeader("Content-Type", "application/json");
+            res.end(JSON.stringify({ error: "Community not found" }));
+            return;
+          }
+
+          next();
+        });
+      },
+      generateBundle() {
+        const prefix = "https://veintiuno.lat";
+        const communitiesWithUrls = communities.map((community) => ({
+          ...community,
+          domain: getCommunityDomain(community),
+          avatarImage: community.avatarImage
+            ? `${prefix}${community.avatarImage}`
+            : undefined,
+          backgroundImage: community.backgroundImage?.startsWith("/")
+            ? `${prefix}${community.backgroundImage}`
+            : community.backgroundImage,
+        }));
+
+        // GET /api/communities.json — list all communities
+        this.emitFile({
+          type: "asset",
+          fileName: "api/communities.json",
+          source: JSON.stringify(communitiesWithUrls, null, 2),
+        });
+
+        // GET /api/community/{domain}.json — get community by domain
+        for (const community of communitiesWithUrls) {
+          if (community.domain) {
+            this.emitFile({
+              type: "asset",
+              fileName: `api/community/${community.domain}.json`,
+              source: JSON.stringify(community, null, 2),
+            });
+          }
+        }
       },
     },
   ],


### PR DESCRIPTION
## Summary
- Add `GET /api/communities` endpoint to list all communities with domain info
- Add `GET /api/community/:domain` endpoint to look up a community by its link domain (e.g. `/api/community/lacrypta.ar`)
- Includes Vite dev server middleware for local development and Vercel rewrites for clean URLs

## Test plan
- [ ] Verify `GET /api/communities` returns all communities as JSON
- [ ] Verify `GET /api/community/lacrypta.ar` returns La Crypta community data
- [ ] Verify unknown domains return 404
- [ ] Verify production build generates static JSON files in `dist/api/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)