### PR TITLE
feat(community): add Discord and Telegram link fields

### DIFF
--- a/src/data/communities.ts
+++ b/src/data/communities.ts
@@ -91,6 +91,8 @@ export const communities: Community[] = [
     link: "https://lacrypta.ar/",
     linkTwitter: "https://twitter.com/lacryptaok",
     linkEmail: "contact@lacrypta.ar",
+    linkDiscord: "https://discord.gg/lacryptaok",
+    linkTelegram: "https://t.me/lacryptaok",
     npub: "lacrypta@hodl.ar",
     latitude: -34.56475340390474,
     longitude: -58.443142884727834,

--- a/src/pages/CommunityPage.tsx
+++ b/src/pages/CommunityPage.tsx
@@ -18,6 +18,8 @@ import {
   Youtube,
   Clock,
   Pickaxe,
+  MessageCircle,
+  Send,
 } from "lucide-react";
 import { Meetup } from "@/types/Meetup";
 import LnPayment from "@/components/payments/LnPayment";
@@ -254,6 +256,26 @@ const CommunityPage: React.FC = () => {
                   >
                     Twitter/X
                     <ExternalLink className='ml-2 h-4 w-4' />
+                  </Button>
+                  )}
+                  {community.linkDiscord && (<Button
+                    className='bg-white hover:bg-gray-100 text-gray-900 border border-gray-300'
+                    onClick={() =>
+                      window.open(`${community.linkDiscord}`, "_blank")
+                    }
+                  >
+                    Discord
+                    <MessageCircle className='ml-2 h-4 w-4' />
+                  </Button>
+                  )}
+                  {community.linkTelegram && (<Button
+                    className='bg-white hover:bg-gray-100 text-gray-900 border border-gray-300'
+                    onClick={() =>
+                      window.open(`${community.linkTelegram}`, "_blank")
+                    }
+                  >
+                    Telegram
+                    <Send className='ml-2 h-4 w-4' />
                   </Button>
                   )}
                   {community.lnAddress && (

--- a/src/types/Community.ts
+++ b/src/types/Community.ts
@@ -5,6 +5,8 @@ export interface Community {
   link: string;
   linkTwitter?: string;
   linkEmail?: string;
+  linkDiscord?: string;
+  linkTelegram?: string;
   npub?: string;
   latitude: number;
   longitude: number;


### PR DESCRIPTION
## Summary

- Adds optional `linkDiscord` and `linkTelegram` fields to the `Community` type
- Populates the La Crypta entry with `https://discord.gg/lacryptaok` and `https://t.me/lacryptaok`
- Renders matching conditional buttons on the community page so the social-link cluster stays consistent with the existing Twitter/X and E-mail buttons

## Files changed

- `src/types/Community.ts` — two new optional `link*` fields next to the existing ones
- `src/data/communities.ts` — La Crypta entry now carries both URLs
- `src/pages/CommunityPage.tsx` — imports `MessageCircle` and `Send` from lucide-react and adds two conditional `<Button>` blocks after the Twitter/X button. Other communities without these fields render nothing extra.

Lucide doesn't ship brand-name Discord/Telegram icons, so generic icons (`MessageCircle`, `Send`) are used — same approach as `linkTwitter`, which uses `ExternalLink` rather than a Twitter glyph.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `npm run dev` and open the La Crypta community page — confirm Discord and Telegram buttons appear after Twitter/X and open the correct URLs in new tabs
- [ ] Open another community page (e.g. one without these fields) — confirm the new buttons do **not** render

🤖 Generated with [Claude Code](https://claude.com/claude-code)