### PR TITLE
fix(communities): working social links + country-scoped city filter

### DIFF
--- a/src/data/communities.ts
+++ b/src/data/communities.ts
@@ -250,7 +250,7 @@ export const communities: Community[] = [
     title: "Bitcoin School Argentina",
     description:
       '"Educación libre, imparcial e independiente en Argentina. Saber cómo ahorrar es un derecho humano." Somos Nodo Completo (Full Node) de la red educativa de Mi Primer Bitcoin. En breve formamos parte de la red Plan B Network tmb. Se hace meetups semanales, BitDevs mensualmente, co-working, hackerspace, y talleres de autocustodia.',
-    link: "https://www.bitcoinschoolar.com",
+    link: "https://bitcoinschoolar.com",
     latitude: -31.42462892556743,
     longitude: -64.183004432926,
     country: "Argentina",

--- a/src/pages/CommunitiesPage.tsx
+++ b/src/pages/CommunitiesPage.tsx
@@ -1,11 +1,7 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { Link } from "react-router-dom";
 import SEOHead from "../components/seo/SEOHead";
-import {
-  communities,
-  getUniqueCountries,
-  getUniqueCities,
-} from "../data/communities";
+import { communities, getUniqueCountries } from "../data/communities";
 import { Community } from "../types/Community";
 import { Card as UICard, CardContent } from "@/components/ui/card";
 import {
@@ -49,8 +45,40 @@ const CommunitiesPage: React.FC = () => {
   const [selectedCountry, setSelectedCountry] = useState<string>("");
   const [selectedCity, setSelectedCity] = useState<string>("");
 
-  const countries = getUniqueCountries();
-  const cities = getUniqueCities();
+  // Countries listed alphabetically
+  const countries = useMemo(
+    () => getUniqueCountries().sort((a, b) => a.localeCompare(b, "es")),
+    []
+  );
+
+  // Cities listed alphabetically, scoped to the selected country (all if none)
+  const cities = useMemo(() => {
+    const source = selectedCountry
+      ? communities.filter((community) => community.country === selectedCountry)
+      : communities;
+    return [
+      ...new Set(
+        source
+          .map((community) => community.city)
+          .filter((city): city is string => Boolean(city))
+      ),
+    ].sort((a, b) => a.localeCompare(b, "es"));
+  }, [selectedCountry]);
+
+  // When the country changes, drop a selected city that no longer belongs to it
+  const handleCountryChange = (country: string) => {
+    setSelectedCountry(country);
+    if (
+      country &&
+      selectedCity &&
+      !communities.some(
+        (community) =>
+          community.country === country && community.city === selectedCity
+      )
+    ) {
+      setSelectedCity("");
+    }
+  };
 
   const filteredCommunities = communities.filter((community) => {
     const matchesCountry =
@@ -177,7 +205,7 @@ const CommunitiesPage: React.FC = () => {
               <div className='flex flex-col md:flex-row gap-4 justify-center items-center mb-8'>
                 <Select
                   value={selectedCountry}
-                  onValueChange={setSelectedCountry}
+                  onValueChange={handleCountryChange}
                 >
                   <SelectTrigger className='w-[200px]'>
                     <SelectValue placeholder='Filtrar por País' />

--- a/src/pages/CommunityPage.tsx
+++ b/src/pages/CommunityPage.tsx
@@ -20,7 +20,9 @@ import {
   Pickaxe,
   MessageCircle,
   Send,
+  Globe,
 } from "lucide-react";
+import { X } from "@/components/icons/x";
 import { Meetup } from "@/types/Meetup";
 import LnPayment from "@/components/payments/LnPayment";
 import { Reveal } from "../components/motion";
@@ -63,6 +65,43 @@ const CommunityPage: React.FC = () => {
   const communityMeetups = meetups
     .filter((meetup) => meetup.organizerCommunity?.id === community.id)
     .slice(0, 3); // Show max 3 meetups
+
+  // Pick an icon + label for a URL based on the platform it points to
+  const getSocialMeta = (
+    url: string
+  ): { Icon: React.ComponentType<{ className?: string }>; label: string } => {
+    const u = url.toLowerCase();
+    if (u.includes("instagram.")) return { Icon: Instagram, label: "Instagram" };
+    if (u.includes("youtube.") || u.includes("youtu.be"))
+      return { Icon: Youtube, label: "YouTube" };
+    if (u.includes("twitter.") || u.includes("x.com"))
+      return { Icon: X, label: "X" };
+    if (u.includes("t.me") || u.includes("telegram."))
+      return { Icon: Send, label: "Telegram" };
+    if (u.includes("whatsapp.") || u.includes("wa.me"))
+      return { Icon: MessageCircle, label: "WhatsApp" };
+    return { Icon: Globe, label: "Sitio web" };
+  };
+
+  // Build the list of working social links from the data this community has
+  const socialLinks: {
+    href: string;
+    Icon: React.ComponentType<{ className?: string }>;
+    label: string;
+  }[] = [];
+  if (community.link) {
+    socialLinks.push({ href: community.link, ...getSocialMeta(community.link) });
+  }
+  if (community.linkTwitter) {
+    socialLinks.push({ href: community.linkTwitter, Icon: X, label: "X" });
+  }
+  if (community.linkEmail) {
+    socialLinks.push({
+      href: `mailto:${community.linkEmail}`,
+      Icon: Mail,
+      label: "E-mail",
+    });
+  }
 
   // MeetupCard component (same as in MeetupsPage)
   const MeetupCard: React.FC<{ meetup: Meetup }> = ({ meetup }) => {
@@ -416,9 +455,21 @@ const CommunityPage: React.FC = () => {
                           Redes Sociales
                         </span>
                         <div className='flex space-x-4 mt-2'>
-                          <ExternalLink className='w-6 h-6 text-gray-600' />
-                          <Instagram className='w-6 h-6 text-gray-600' />
-                          <Youtube className='w-6 h-6 text-gray-600' />
+                          {socialLinks.map(({ href, Icon, label }) => (
+                            <a
+                              key={`${label}-${href}`}
+                              href={href}
+                              target={
+                                href.startsWith("mailto:") ? undefined : "_blank"
+                              }
+                              rel='noopener noreferrer'
+                              aria-label={label}
+                              title={label}
+                              className='text-gray-600 hover:text-bitcoin transition-colors'
+                            >
+                              <Icon className='w-6 h-6' />
+                            </a>
+                          ))}
                         </div>
                       </div>
                     </CardContent>


### PR DESCRIPTION
## What & why

Three fixes to the Communities experience, all surfaced while QAing community pages.

### 1. Community page — make the "Redes Sociales" links actually work
The "Redes Sociales" block in the community detail page rendered three **static, non-clickable** icons (ExternalLink / Instagram / YouTube) that pointed nowhere — and Instagram/YouTube had no backing data. Replaced them with **data-driven anchor links** built from each community's real fields (`link`, `linkTwitter`, `linkEmail`), with the icon auto-detected from the URL (Instagram, YouTube, X, Telegram, WhatsApp, or a generic website Globe). Links open in a new tab with `rel="noopener noreferrer"` (and `mailto:` for email), plus `aria-label`/`title` for accessibility.

> Note: this is independent of the Discord/Telegram **hero buttons** added in #54 — those live in the hero; this fixes the separate "Redes Sociales" row in the Fechas card, which still had the old static icons.

### 2. Communities page — alphabetical, country-scoped filters
- Both the **País** and **Ciudad** dropdowns are now sorted alphabetically (locale-aware, so *México*, *Perú*, *Córdoba* order correctly).
- The **Ciudad** dropdown is now scoped to the selected country — it only lists cities in that country, and shows all cities when no country is selected.
- Switching to a country that doesn't contain the currently-selected city resets the city, so you can't end up with a contradictory País+Ciudad combo.

### 3. Data — fix Bitcoin School Argentina website link
`https://www.bitcoinschoolar.com` served a TLS cert that doesn't cover the `www` host (curl error 60). The bare domain resolves fine, so the link now points to `https://bitcoinschoolar.com`.

## Testing
- `tsc -p tsconfig.app.json --noEmit` — clean for the changed files.
- Verified in the running dev server against the current redesigned UI:
  - **la-crypta** social links → Sitio web / X / E-mail resolve correctly; Instagram detection works for communities whose website is an IG URL (e.g. bitcoin-pichilemu); Telegram for `t.me` links.
  - Country dropdown: 15 countries, alphabetical (Argentina → Uruguay).
  - City dropdown: all 25 cities when no country; narrows to exactly the selected country's cities (Argentina → 4, Cuba → 2); resets stale city on country change.

## Reviewer notes
This branch was rebased onto the latest `main`, so the diff is limited to the 3 files below. The `CommunityPage.tsx` social-links rework was re-applied on top of the recent redesign / SEO overhaul; the only merge overlap was the lucide-react import list (unioned `Globe`/`Send`/`MessageCircle`).